### PR TITLE
wip test

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "npm run build && node build/bin/www.js",
     "build": "tsc",
+    "test": "jest",
     "develop": "nodemon",
     "serve": "node build/bin/www.js",
     "migrate:latest": "knex migrate:latest --knexfile ./database/knexfile.js",

--- a/backend/src/test/bmi.test.js
+++ b/backend/src/test/bmi.test.js
@@ -1,0 +1,40 @@
+      /// <reference types="jest" />
+   import request from 'supertest'
+   import app from '../src/app'
+
+   describe('BMI API', () => {
+   it('should create a new BMI record', async () => {
+      const res = await request(app)
+         .post('/api/create/bmi')
+         .send({
+         id: Math.floor(Math.random() * 1000000),
+         height: 1.75,
+         weight: 70,
+         age: 25,
+         bmi: 22.86
+         })
+         .set('Accept', 'application/json')
+
+      expect(res.status).toBe(201)
+      expect(res.body).toHaveProperty('id')
+      expect(res.body.height).toBe(1.75)
+      expect(res.body.weight).toBe(70)
+      expect(res.body.age).toBe(25)
+      expect(res.body.bmi).toBeCloseTo(22.86)
+   })
+
+   it('should fail with missing fields', async () => {
+      const res = await request(app)
+         .post('/api/create/bmi')
+         .send({
+         height: 1.75,
+         weight: 70,
+         age: 25
+         // bmi missing
+         })
+         .set('Accept', 'application/json')
+
+      expect(res.status).toBe(400)
+      expect(res.body).toHaveProperty('message', 'Missing required fields')
+   })
+   })


### PR DESCRIPTION
## Summary by Sourcery

Enable Jest testing in the backend and introduce integration tests for the BMI API endpoint

Build:
- Add "test" script to package.json to enable running Jest

Tests:
- Add Jest-based integration tests for the BMI API covering successful record creation and missing-fields validation